### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 2. Clone this repository and navigate to LITA folder
 ```bash
-git clone https://gitlab-master.nvidia.com/deahuang/LITA.git
+git clone https://github.com/NVlabs/LITA.git
 cd LITA
 ```
 


### PR DESCRIPTION
Update URL from NVLab. The old URL is located in gitlab-master inside NVIDIA's org which is not accessible to the outside world, it won't work without this commit.